### PR TITLE
JPERF-902: Print stacktraces on gradle task failure by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+gradle.startParameter.showStacktrace = org.gradle.api.logging.configuration.ShowStacktrace.ALWAYS
+
 val kotlinVersion = "1.2.70"
 val seleniumVersion = "3.141.59"
 val log4jVersion = "2.17.2"


### PR DESCRIPTION
We currently have a problem that the release process on Github Actions is reporting some failure, however the cause it not fully clear. Showing stacktrace of the task could reveal more information.

Possibly the setting is worth to keep, as we probably always are interested in sourcecode cause when an exception is thrown.
Exceptions seem to usually rely on their stacktraces to be diagnosable. In our case message "https://github.com/atlassian/jira-software-actions: not authorized" doesn't give much context.