### PR TITLE
JPERF-902: Use GITHUB_TOKEN for CI authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,5 +68,5 @@ jobs:
         atlassian_private_username: ${{ steps.publish-token.outputs.artifactoryUsername }}
         atlassian_private_password: ${{ steps.publish-token.outputs.artifactoryApiKey }}
       run: |
-        ./gradlew release -Prelease.customUsername=${{ secrets.REPOSITORY_ACCESS_TOKEN }}
+        ./gradlew release -Prelease.customUsername=${{ secrets.GITHUB_TOKEN }}
         ./gradlew publish


### PR DESCRIPTION
The release process stopped working and seems to be failing on git tag push operation. Refreshing the currently used `REPOSITORY_ACCESS_TOKEN` should work, however it's a short term solution and applying it takes away a simple opportunity of testing a proper fix.

Based on https://docs.github.com/en/actions/security-guides/automatic-token-authentication and https://stackoverflow.com/a/57932145
I believe this GITHUB_TOKEN should work for git operations.

We do already have proper permissions set, i.e. "Read and write permissions" under "Workflow Permissions"

We can revert this change if it won't work.