### PR TITLE
JPERF-902: Grant "contents write" access to GITHUB_TOKEN used in release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     needs: build-check
     if: github.event.inputs.release == 'yes'


### PR DESCRIPTION
Because we have `permissions` defined for the `release` job [here](https://github.com/atlassian/jira-software-actions/blob/a36750e1cffe26e7ef10459adb55f89a48d38c56/.github/workflows/ci.yml#L48) the default set on the repository level
[here (at the end of the page)](https://github.com/atlassian/jira-software-actions/settings/actions) is not used.

We need a permission to be able to create release tags in the repository. The release tags are essential metadata in [gradle-release](https://bitbucket.org/atlassian/gradle-release) plugin, which we are using.

Based on description of scopes for different feature of GitHub I believe the `contents` permission is the right one. Under https://github.com/settings/personal-access-tokens/new we can find it summarized as "Repository contents, commits, branches, downloads, releases, and merges.".