### PR TITLE
JPERF-902: Apply exact instructions for release task from the plugin we are using

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,5 +68,7 @@ jobs:
         atlassian_private_username: ${{ steps.publish-token.outputs.artifactoryUsername }}
         atlassian_private_password: ${{ steps.publish-token.outputs.artifactoryApiKey }}
       run: |
-        ./gradlew release -Prelease.customUsername=${{ secrets.GITHUB_TOKEN }}
+        ./gradlew release \
+            -Prelease.customUsername=${{ github.actor }} \
+            -Prelease.customPassword=${{ github.token }}
         ./gradlew publish


### PR DESCRIPTION
The release process is still not working on CI. I still believe it's due to credentials. Apparently the cyrrent way doesn't work with the automated token.

The changed way of passing credentials is based on https://axion-release-plugin.readthedocs.io/en/latest/configuration/ci_servers/#github-actions This plugin is used as part of gradle-release