### PR TITLE
JPERF-903 Fix flakiness caused by AUI flag obscuring the menu button on the backlog view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-software-actions/compare/release-1.4.0...master
 
+### Fixed
+- Fix flakiness of `WorkOnBacklog` action caused by AUI Flag obscuring edit sprint button. Resolve [JPERF-903]
+
 ## [1.4.0] - 2022-12-15
 [1.4.0]: https://github.com/atlassian/jira-software-actions/compare/release-1.3.6...release-1.4.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ configurations.all {
 }
 
 dependencies {
-    api("com.atlassian.performance.tools:jira-actions:[3.17.3,4.0.0)")
+    api("com.atlassian.performance.tools:jira-actions:[3.18.0,4.0.0)")
     api("com.github.stephenc.jcip:jcip-annotations:1.0-1")
     api(webdriver("selenium-api"))
 

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:concurrency:1.1.2
-com.atlassian.performance.tools:jira-actions:3.17.3
+com.atlassian.performance.tools:jira-actions:3.18.0
 com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.atlassian.performance.tools:jira-actions:3.17.3
+com.atlassian.performance.tools:jira-actions:3.18.0
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:concurrency:1.1.2
-com.atlassian.performance.tools:jira-actions:3.17.3
+com.atlassian.performance.tools:jira-actions:3.18.0
 com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:concurrency:1.1.2
-com.atlassian.performance.tools:jira-actions:3.17.3
+com.atlassian.performance.tools:jira-actions:3.18.0
 com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:concurrency:1.1.2
-com.atlassian.performance.tools:jira-actions:3.17.3
+com.atlassian.performance.tools:jira-actions:3.18.0
 com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance:selenium-js:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:docker-infrastructure:0.3.6
-com.atlassian.performance.tools:jira-actions:3.17.3
+com.atlassian.performance.tools:jira-actions:3.18.0
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
 com.github.docker-java:docker-java-api:3.2.7

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -4,7 +4,7 @@
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:docker-infrastructure:0.3.6
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.17.3
+com.atlassian.performance.tools:jira-actions:3.18.0
 com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -4,7 +4,7 @@
 com.atlassian.performance.tools:concurrency:1.1.2
 com.atlassian.performance.tools:docker-infrastructure:0.3.6
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jira-actions:3.17.3
+com.atlassian.performance.tools:jira-actions:3.18.0
 com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance:selenium-js:1.0.1
 com.fasterxml.jackson.core:jackson-annotations:2.10.3

--- a/src/main/kotlin/com/atlassian/performance/tools/jirasoftwareactions/api/actions/WorkOnBacklog.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jirasoftwareactions/api/actions/WorkOnBacklog.kt
@@ -47,6 +47,7 @@ class WorkOnBacklog private constructor(
     }
 
     private fun editSprint(backlog: ViewBacklogPage) {
+        backlog.closePopups()
         val sprint = backlog.listSprints().firstOrNull()
         if (sprint != null) {
             meter.measure(

--- a/src/main/kotlin/com/atlassian/performance/tools/jirasoftwareactions/api/page/ViewBacklogPage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jirasoftwareactions/api/page/ViewBacklogPage.kt
@@ -1,6 +1,7 @@
 package com.atlassian.performance.tools.jirasoftwareactions.api.page
 
 import com.atlassian.performance.tools.jiraactions.api.page.wait
+import com.atlassian.performance.tools.jiraactions.api.page.NotificationPopUps
 import com.atlassian.performance.tools.jirasoftwareactions.webdriver.JavaScriptUtils
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
@@ -13,6 +14,7 @@ class ViewBacklogPage(
     private val driver: WebDriver
 ) {
     private val sprintsLocator = By.cssSelector(".ghx-sprint-group .ghx-backlog-container")
+    private val popUps = NotificationPopUps(driver)
 
     fun waitForBacklog(): WebElement? {
         return driver.wait(
@@ -37,5 +39,9 @@ class ViewBacklogPage(
             Duration.ofSeconds(30),
             textToBePresentInElementLocated(By.cssSelector(".ghx-backlog-container .ghx-name"), expectedSprintName)
         )
+    }
+
+    fun closePopups() {
+        popUps.waitUntilAuiFlagsAreGone()
     }
 }


### PR DESCRIPTION
The backlog page has now knowledge about existing notification popups and has the ability to close them. This functionality is now used to hide AUI flags before starting Edit Sprint Action to make sure nothing obscures the edit sprint button.