### PR TITLE
JPERF-906 Use randomly generated string as a new sprint name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-software-actions/compare/release-1.4.1...master
 
+### Fixed
+- Set the sprint name used for editing sprint to a random value. Resolve [JPERF-906]
+
 ## [1.4.1] - 2022-12-15
 [1.4.1]: https://github.com/atlassian/jira-software-actions/compare/release-1.4.0...1.4.1
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jirasoftwareactions/api/actions/WorkOnBacklog.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jirasoftwareactions/api/actions/WorkOnBacklog.kt
@@ -31,7 +31,7 @@ class WorkOnBacklog private constructor(
     }
 
     private val logger: Logger = LogManager.getLogger(this::class.java)
-    private val newSprintName = "New Sprint Name"
+    private val newSprintName = "Sprint Name - " + System.nanoTime()
 
     override fun run() {
         val board = boardMemory.recall { filter.test(it) }


### PR DESCRIPTION
Having the sprint name hardcoded can lead to a situation where both new and old names are the same. As a result, the timings of Edit Sprint Action might be faulty. Randomly generated name prevents such situations.